### PR TITLE
Minor: fix for addon list in dark themes

### DIFF
--- a/skin/scss/addons.scss
+++ b/skin/scss/addons.scss
@@ -363,13 +363,13 @@ page[aios-inSidebar] {
         background-image: none;
 
         .addon:not([selected="true"]) {
-            background-color: #FFFFFF;
+            background-color: ButtonFace;
         }
 
         #categories {
             border-top: none;
             border-bottom: 1px solid ThreedShadow;
-            background-color: #ffffff;
+            background-color: Menu;
         }
 
         .category,


### PR DESCRIPTION
This is a minor fix to prevent this kind of theme mismatch with dark themes:

![dark theme mismatch](https://cloud.githubusercontent.com/assets/5386578/3931058/d046f380-2451-11e4-92ef-74cb0cdba2b0.png)
